### PR TITLE
feat: Improve script injection and migrate to Manifest V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /*.log
 /dist
 /dist-zip
+/dist-firefox
+/dist-zip-firefox
 coverage
 .env
 .DS_Store

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,8 @@
   "name": "Vue Telescope",
   "description": "Discover Vue.js Websites",
   "version": "1.0.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
+  "minimum_chrome_version": "102",
   "icons": {
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",
@@ -15,7 +16,7 @@
       "js": ["content.js"]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "icons/icon-grey-16.png",
       "48": "icons/icon-grey-48.png",
@@ -25,9 +26,24 @@
     "default_popup": "popup/popup.html"
   },
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
-  "permissions": ["https://*/*"],
-  "content_security_policy": "script-src 'self'; object-src 'self'",
-  "web_accessible_resources": ["injected.js"]
+  "permissions": ["https://*/*", "scripting"],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "injected.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "extension_ids": []
+    }
+  ]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,0 +1,34 @@
+{
+    "name": "Vue Telescope",
+    "description": "Discover Vue.js Websites",
+    "version": "1.0.0",
+    "manifest_version": 2,
+    "icons": {
+      "16": "icons/icon-16.png",
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
+    },
+    "content_scripts": [
+      {
+        "run_at": "document_start",
+        "matches": ["<all_urls>"],
+        "js": ["content.js"]
+      }
+    ],
+    "browser_action": {
+      "default_icon": {
+        "16": "icons/icon-grey-16.png",
+        "48": "icons/icon-grey-48.png",
+        "128": "icons/icon-grey-128.png"
+      },
+      "default_title": "Vue Telescope",
+      "default_popup": "popup/popup.html"
+    },
+    "background": {
+      "scripts": ["background.js"]
+    },
+    "permissions": ["https://*/*"],
+    "content_security_policy": "script-src 'self'; object-src 'self'",
+    "web_accessible_resources": ["injected.js"]
+}
+  

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint --ext .js,.vue src",
     "build:dev": "cross-env NODE_ENV=development webpack --hide-modules",
     "build-zip": "node scripts/build-zip.js",
+    "build-zip:firefox": "node scripts/build-zip.js --build-browser firefox",
     "watch:tailwind": "NODE_ENV=development postcss src/tailwind.css -o dist/tailwind.css -w",
     "dev:tailwind": "NODE_ENV=development postcss src/tailwind.css -o dist/tailwind.css",
     "build:tailwind": "NODE_ENV=production postcss src/tailwind.css -o dist/tailwind.css",
@@ -18,6 +19,7 @@
     "watch:dev": "cross-env HMR=true npm run build:dev -- --watch",
     "dev": "concurrently \"npm run watch:tailwind\" \"npm run watch:dev\"",
     "build": "npm run build:tailwind && webpack --mode production",
+    "build:firefox": "npm run build:tailwind && webpack --mode production --build-browser firefox && cp dist/tailwind.css dist-firefox/tailwind.css",
     "release": "standard-version && git push --follow-tags origin master"
   },
   "dependencies": {
@@ -60,6 +62,7 @@
     "google-fonts-webpack-plugin": "^0.4.4",
     "html-loader": "^1.1.0",
     "mini-css-extract-plugin": "^0.9.0",
+    "minimist": "^1.2.8",
     "standard-version": "^8.0.2",
     "vue-loader": "^15.4.2",
     "vue-svg-loader": "^0.16.0",
@@ -67,6 +70,6 @@
     "web-ext-types": "^2.1.0",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.3.10",
-    "webpack-extension-reloader": "^1.1.0"
+    "webpack-extension-reloader": "^1.1.4"
   }
 }

--- a/scripts/build-zip.js
+++ b/scripts/build-zip.js
@@ -4,8 +4,14 @@ const fs = require('fs')
 const path = require('path')
 const archiver = require('archiver')
 
-const DEST_DIR = path.join(__dirname, '../dist')
-const DEST_ZIP_DIR = path.join(__dirname, '../dist-zip')
+const argv = require('minimist')(process.argv.slice(2))
+const browser = argv['build-browser'] || 'chrome'
+const isFireFox = browser === 'firefox'
+
+const distSuffix = isFireFox ? '-firefox' : ''
+
+const DEST_DIR = path.join(__dirname, `../dist${distSuffix}`)
+const DEST_ZIP_DIR = path.join(__dirname, `../dist-zip${distSuffix}`)
 
 const extractExtensionData = () => {
   const extPackageJson = require('../package.json')

--- a/src/content.js
+++ b/src/content.js
@@ -1,15 +1,26 @@
+import { IS_FIREFOX, isSupportExecutionVersion } from './utils'
 const browser = require('webextension-polyfill')
 
-// injecting the script
+// injecting the script, inspire by react-devtools-extensions
+function injectScriptSync (src) {
+  let code = ''
+  const request = new XMLHttpRequest()
+  request.addEventListener('load', function () {
+    code = this.responseText
+  })
+  request.open('GET', src, false)
+  request.send()
+  const script = document.createElement('script')
+  script.textContent = code
+  // This script runs before the <head> element is created, so we add the script to <html> instead.
+  document.documentElement.appendChild(script)
+  script.parentNode.removeChild(script)
+}
 
-const content = browser.extension.getURL('injected.js')
-const script = document.createElement('script')
-script.setAttribute('defer', 'defer')
-script.setAttribute('type', 'text/javascript')
-script.setAttribute('src', content)
-// document.body.appendChild(script)
-document.documentElement.appendChild(script)
-script.parentNode.removeChild(script)
+// equivalent logic for other browser is in background.js
+if (IS_FIREFOX || !isSupportExecutionVersion) {
+  injectScriptSync(browser.extension.getURL('injected.js'))
+}
 
 // content script logic
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,11 @@
+export const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0
+export const IS_CHROME = /Chrome/i.test(navigator.userAgent)
+export function getChromeVersion () {
+  const ua = navigator.userAgent
+  const match = ua.match(/Chrome\/(\d+)/)
+  const version = match ? parseInt(match[1], 10) : null
+  return version
+}
+
+const chromeVersion = getChromeVersion()
+export const isSupportExecutionVersion = chromeVersion && chromeVersion >= 102

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,6 +4925,11 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -7409,9 +7414,9 @@ webpack-cli@^3.3.10:
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
 
-webpack-extension-reloader@^1.1.0:
+webpack-extension-reloader@^1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/webpack-extension-reloader/-/webpack-extension-reloader-1.1.4.tgz#f5e5fa580e617c114cc45ddb6eb25c5d6a4dd2f6"
+  resolved "https://registry.npmjs.org/webpack-extension-reloader/-/webpack-extension-reloader-1.1.4.tgz#f5e5fa580e617c114cc45ddb6eb25c5d6a4dd2f6"
   integrity sha512-PyssJvAiKhztc//QmhpU8yfg7LBR7Bn/cjSM7jadfQJPIDNN1Djxc+SJQRk8uHQ3GQbyWhsWu2DLCMBRcWHIPA==
   dependencies:
     "@types/webpack" "^4.39.8"


### PR DESCRIPTION
resolve #17  #16 

Hello, I have solved the problem of script injection displayed in the network (PS: partially based on the idea of react-devtools-extensions, the code has notes). During the process, I migrated to Manifest v3 because I could not use the `browser.scripting` property. However, Firefox does not support Manifest v3, so I built two dist dir.

Now it runs well, and I have tested it locally on Firefox and Chrome. Do you have any other suggestions?

**Before:**
![before](https://user-images.githubusercontent.com/74137084/229130770-40a1f0ba-d1d0-4fdb-8f6d-e86c7e7a8dd1.png)

**After:**
![截屏2023-03-31 11 16 39](https://user-images.githubusercontent.com/74137084/229130882-d5172269-f0c8-4547-bad7-0e2684d73e46.png)

