### PR TITLE
fix: use `runtime.getURL` instead of `extension.getURL`

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,9 @@
-import { IS_FIREFOX, isSupportExecutionVersion } from './utils'
+import { IS_CHROME, IS_FIREFOX, isSupportExecutionVersion } from './utils'
 const browser = require('webextension-polyfill')
 
 const tabsStorage = {}
 
-if (!IS_FIREFOX && isSupportExecutionVersion) {
+if (IS_CHROME && isSupportExecutionVersion) {
   /**
    *  equivalent logic for Firefox is in content.js
    *  Manifest V3 method of injecting content scripts (not yet supported in Firefox)

--- a/src/content.js
+++ b/src/content.js
@@ -1,29 +1,22 @@
-import { IS_FIREFOX, isSupportExecutionVersion } from './utils'
+import { IS_CHROME, isSupportExecutionVersion } from './utils'
 const browser = require('webextension-polyfill')
 
-// injecting the script, inspire by react-devtools-extensions
-function injectScriptSync (src) {
-  let code = ''
-  const request = new XMLHttpRequest()
-  request.addEventListener('load', function () {
-    code = this.responseText
-  })
-  request.open('GET', src, false)
-  request.send()
+// injecting the script
+function injectScript (src) {
   const script = document.createElement('script')
-  script.textContent = code
-  // This script runs before the <head> element is created, so we add the script to <html> instead.
+  script.setAttribute('defer', 'defer')
+  script.setAttribute('type', 'text/javascript')
+  script.setAttribute('src', src)
   document.documentElement.appendChild(script)
   script.parentNode.removeChild(script)
 }
 
 // equivalent logic for other browser is in background.js
-if (IS_FIREFOX || !isSupportExecutionVersion) {
-  injectScriptSync(browser.extension.getURL('injected.js'))
+if (!IS_CHROME || !isSupportExecutionVersion) {
+  injectScript(browser.runtime.getURL('injected.js'))
 }
 
 // content script logic
-
 browser.runtime.onMessage.addListener(messageFromBackground)
 
 function messageFromBackground (message) {


### PR DESCRIPTION
issue: https://github.com/nuxtlabs/vue-telescope-extensions/pull/18#issuecomment-1514268694

Details: When the UA is modified, the chrome version cannot be obtained, resulting in the error injected logic.`chrome.extension.getURL` deprecated since Chrome 58,use `runtime.getURL` instead of it.This API is also supported after Firefox 45.

