### PR TITLE
fix: typo in error message

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -64,7 +64,7 @@
         class="absolute top-0 left-0 flex items-center justify-center w-full h-full"
       >
         <div class="font-bold-body-weight text-eight">
-          Please enter an url in the address bar.
+          Please enter a url in the address bar.
         </div>
       </div>
 


### PR DESCRIPTION
since [the pronounciation starts with "j"](https://dictionary.cambridge.org/pronunciation/english/url), it should be `a` instead of `an` 