### PR TITLE
fix: refresh analyzed data for tab if url has changed

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -89,7 +89,8 @@ browser.runtime.onMessage.addListener(
       const tabId = (sender.tab && sender.tab.id) || message.payload.tabId
 
       const tabs = await tabsState.get()
-      if (!tabs[tabId]) {
+      // set/overwrite analyzed data on new tab/url
+      if (!tabs[tabId] || tabs[tabId].url !== message.payload.url) {
         tabs[tabId] = message.payload
       } else {
         // temporary fix when hit CSP


### PR DESCRIPTION
* https://github.com/nuxtlabs/vue-telescope-analyzer/pull/107 may be relevant as well when testing

While checking the analyzed result on different websites it seemed to merge the results of the previously visited websites on the same tab, this checks if the url has changed, I suppose detection can change per page anyway.